### PR TITLE
Fix missing "block/dataform:addinstance" capability.

### DIFF
--- a/db/access.php
+++ b/db/access.php
@@ -1,0 +1,18 @@
+<?php
+
+$capabilities = array(
+
+    'block/dataform:addinstance' => array(
+        'riskbitmask' => RISK_SPAM,
+
+        'captype' => 'write',
+        'contextlevel' => CONTEXT_BLOCK,
+        'archetypes' => array(
+            'manager' => CAP_ALLOW,
+            'editingteacher' => CAP_ALLOW,
+            'coursecreator' => CAP_ALLOW
+        ),
+
+        'clonepermissionsfrom' => 'moodle/site:manageblocks'
+    )
+);


### PR DESCRIPTION
Got this warning while using it under Moodle 2.4/5
